### PR TITLE
Add optical animations

### DIFF
--- a/Client/app/page.tsx
+++ b/Client/app/page.tsx
@@ -15,6 +15,7 @@ import GlassesRayban from "@/components/demo/rayban.glasses"
 import KidsGlasses from "@/components/demo/kids.glasses"
 import ExperienceSection from "@/components/demo/experience.section"
 import Footer from "@/components/demo/footer"
+import AnimatedSection from "@/components/ui/animated-section"
 
 export default function OpticaCVPlus() {
   return (
@@ -23,25 +24,43 @@ export default function OpticaCVPlus() {
       <Nav />
       <main className="flex-1">
         {/* Hero Section */}
-        <HeroSection/>
-        <Brands/>
+        <AnimatedSection>
+          <HeroSection />
+        </AnimatedSection>
+        <AnimatedSection>
+          <Brands />
+        </AnimatedSection>
         {/* Glasses Section */}
-        <Glasses />
+        <AnimatedSection>
+          <Glasses />
+        </AnimatedSection>
         {/* Hugo Boss Section */}
-        <HugoBoss />
+        <AnimatedSection>
+          <HugoBoss />
+        </AnimatedSection>
 
         {/* Ray-Ban Section */}
-        <RaybanSection />
-        <GlassesRayban/>
+        <AnimatedSection>
+          <RaybanSection />
+        </AnimatedSection>
+        <AnimatedSection>
+          <GlassesRayban />
+        </AnimatedSection>
 
         {/* Test Exam Section */}
-        <TestExam />
+        <AnimatedSection>
+          <TestExam />
+        </AnimatedSection>
 
         {/* Kids Glasses Section */}
-        <KidsGlasses />
+        <AnimatedSection>
+          <KidsGlasses />
+        </AnimatedSection>
 
         {/* Experience Section */}
-        <ExperienceSection />
+        <AnimatedSection>
+          <ExperienceSection />
+        </AnimatedSection>
       </main>
 
       {/* Footer */}

--- a/Client/components/demo/hero.section.tsx
+++ b/Client/components/demo/hero.section.tsx
@@ -16,6 +16,11 @@ const HeroSection = () => {
           {/* Capa opcional de oscurecimiento */}
           <div className="absolute inset-0 bg-black/40 z-10"></div>
 
+          {/* Capa animada representando un lente */}
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10 animate-rotate-slow">
+            <div className="w-[120%] h-[120%] rounded-full bg-gradient-radial from-tiffanyBlue/30 via-white/20 to-transparent animate-focus-glow" />
+          </div>
+
           {/* Contenido visible */}
           <div className="relative z-20 flex flex-col items-center justify-end text-center h-full text-white px-4 pb-16">
             <img src="/svg/ray-meta.svg" alt="Ray Meta" className="pb-6" />

--- a/Client/components/ui/animated-section.tsx
+++ b/Client/components/ui/animated-section.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { PropsWithChildren } from "react";
+
+interface AnimatedSectionProps {
+  className?: string;
+}
+
+export default function AnimatedSection({ children, className = "" }: PropsWithChildren<AnimatedSectionProps>) {
+  return (
+    <motion.section
+      className={className}
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ duration: 0.6, ease: "easeOut" }}
+    >
+      {children}
+    </motion.section>
+  );
+}

--- a/Client/package.json
+++ b/Client/package.json
@@ -57,6 +57,7 @@
     "swiper": "^11.2.10",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
+    "framer-motion": "^11.1.6",
     "vaul": "^0.9.6",
     "zod": "^3.24.1"
   },

--- a/Client/tailwind.config.ts
+++ b/Client/tailwind.config.ts
@@ -73,29 +73,39 @@ const config: Config = {
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
   		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		}
-  	}
+                keyframes: {
+                        'accordion-down': {
+                                from: {
+                                        height: '0'
+                                },
+                                to: {
+                                        height: 'var(--radix-accordion-content-height)'
+                                }
+                        },
+                        'accordion-up': {
+                                from: {
+                                        height: 'var(--radix-accordion-content-height)'
+                                },
+                                to: {
+                                        height: '0'
+                                }
+                        },
+                        'rotate-slow': {
+                                from: { transform: 'rotate(0deg)' },
+                                to: { transform: 'rotate(360deg)' }
+                        },
+                        'focus-glow': {
+                                '0%, 100%': { opacity: '0.3', transform: 'scale(1)' },
+                                '50%': { opacity: '0.6', transform: 'scale(1.3)' }
+                        }
+                },
+                animation: {
+                        'accordion-down': 'accordion-down 0.2s ease-out',
+                        'accordion-up': 'accordion-up 0.2s ease-out',
+                        'rotate-slow': 'rotate-slow 30s linear infinite',
+                        'focus-glow': 'focus-glow 6s ease-in-out infinite'
+                }
+        }
   },
   plugins: [require("tailwindcss-animate")],
 };


### PR DESCRIPTION
## Summary
- implement AnimatedSection wrapper with framer-motion
- wrap demo sections so they fade in on scroll
- include framer-motion dependency

## Testing
- `pnpm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6873df88f6248331b292db6e63182be4