### PR TITLE
Add dropdown nav menu with blurred backdrop

### DIFF
--- a/Client/components/demo/nav.tsx
+++ b/Client/components/demo/nav.tsx
@@ -3,14 +3,25 @@
 import { icon, nav } from "@/constants/demo.constants";
 import { Download, Headset, Store, Menu } from "lucide-react";
 import Link from "next/link";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/components/ui/sheet";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Autoplay } from "swiper/modules";
 import "swiper/css";
 
 const Nav = () => {
+    const [openItem, setOpenItem] = useState<string | null>(null);
+
     return (
-        <header className="fixed top-0 z-50 w-full border-b pb-2 bg-white backdrop-blur">
+        <>
+        {openItem && (
+            <div
+                onClick={() => setOpenItem(null)}
+                className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
+            />
+        )}
+        <header className="fixed top-0 z-50 w-full border-b pb-2 bg-white">
             {/* Banner superior - Solo desktop */}
             <div className="hidden xl:block h-[36px] bg-[#f6f6f6]">
                 <div className="w-[95%] mx-auto flex flex-row justify-between h-full">
@@ -68,7 +79,7 @@ const Nav = () => {
             </div>
 
             {/* Navegación principal */}
-            <div className="flex h-16 items-center justify-between w-[90%] mx-auto">
+            <div className="relative flex h-16 items-center justify-between w-[90%] mx-auto">
                 {/* Logo */}
                 <div className="flex items-center space-x-2">
                     <img src="/logo.png" alt="Óptica CV+" className="w-[256px]" />
@@ -77,15 +88,30 @@ const Nav = () => {
                 {/* Navegación */}
                 <nav className="hidden xl:flex items-center space-x-8 justify-center">
                     {nav.map((item) => (
-                        <Link
+                        <button
                             key={item.href}
-                            href={item.href}
-                            className="relative text-md font-medium font-sans uppercase transition-all duration-300 hover:text-tiffanyBlue after:content-[''] after:absolute after:left-0 after:bottom-[-4px] after:h-[2px] after:w-0 after:bg-tiffanyBlue after:transition-all after:duration-300 hover:after:w-full"
+                            onClick={() => setOpenItem(item.name)}
+                            className={cn(
+                                "relative text-md font-medium font-sans uppercase transition-all duration-300 after:content-[''] after:absolute after:left-0 after:bottom-[-4px] after:h-[2px] after:bg-tiffanyBlue after:transition-all after:duration-300",
+                                openItem === item.name
+                                    ? "text-tiffanyBlue after:w-full"
+                                    : "after:w-0 hover:text-tiffanyBlue hover:after:w-full"
+                            )}
                         >
                             {item.name}
-                        </Link>
+                        </button>
                     ))}
                 </nav>
+                {openItem && (
+                    <div className="absolute left-0 top-full w-full bg-white shadow-lg z-50 py-4">
+                        <div className="w-[90%] mx-auto flex flex-col gap-3">
+                            <span className="font-semibold text-lg mb-2">{openItem}</span>
+                            <Link href="#" className="text-sm hover:underline">Sub opción 1</Link>
+                            <Link href="#" className="text-sm hover:underline">Sub opción 2</Link>
+                            <Link href="#" className="text-sm hover:underline">Sub opción 3</Link>
+                        </div>
+                    </div>
+                )}
 
                 {/* Botones y iconos */}
                 <div className="flex items-center space-x-4">
@@ -123,13 +149,14 @@ const Nav = () => {
                             </div>
                             <nav className="flex flex-col space-y-4 mt-8">
                                 {nav.map((item) => (
-                                    <Link
-                                        key={item.href}
-                                        href={item.href}
-                                        className="text-base font-medium uppercase text-gray-700 hover:text-tiffanyBlue"
-                                    >
-                                        {item.name}
-                                    </Link>
+                                    <SheetClose asChild key={item.href}>
+                                        <button
+                                            onClick={() => setOpenItem(item.name)}
+                                            className="text-left text-base font-medium uppercase text-gray-700 hover:text-tiffanyBlue"
+                                        >
+                                            {item.name}
+                                        </button>
+                                    </SheetClose>
                                 ))}
                             </nav>
                         </SheetContent>
@@ -137,6 +164,7 @@ const Nav = () => {
                 </div>
             </div>
         </header>
+        </>
     )
 }
 

--- a/Client/components/ui/dialog.tsx
+++ b/Client/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- remove dialog in nav and replace with custom dropdown menu
- keep nav bar solid and highlight active item
- blur page background when dropdown is open

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6873fd6413b08331bc77348239818fec